### PR TITLE
Allow overriding the full_message error format

### DIFF
--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -364,12 +364,50 @@ module ActiveModel
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
+    #
+    #   The `"%{attribute} %{message}"` error format can be overridden either
+    #
+    # * <tt>activemode.errors.models/person/contacts/addresses.attributes.street.format</tt>
+    # * <tt>activemodel.errors.models.person/contacts/addresses.format</tt>
+    # * <tt>activemodel.errors.models.person.attributes.name.format</tt>
+    # * <tt>activemodel.errors.models.person.format</tt>
+    # * <tt>errors.format</tt>
     def full_message(attribute, message)
       return message if attribute == :base
+
+      parts = attribute.to_s.split(".")
+      attribute_name = parts.pop
+      namespace = parts.join("/") unless parts.empty?
+
+      if @base.class.respond_to?(:i18n_scope)
+        attributes_scope = "#{@base.class.i18n_scope}.errors.models"
+        if namespace
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
+            ]
+          end
+        else
+          defaults = @base.class.lookup_ancestors.map do |klass|
+            [
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
+              :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
+            ]
+          end
+        end
+      else
+        defaults = []
+      end
+
+      defaults.flatten!
+      defaults << :"errors.format"
+      defaults << "%{attribute} %{message}"
+
       attr_name = attribute.to_s.tr(".", "_").humanize
       attr_name = @base.class.human_attribute_name(attribute, default: attr_name)
-      I18n.t(:"errors.format",
-        default:  "%{attribute} %{message}",
+      I18n.t(defaults.shift,
+        default:  defaults,
         attribute: attr_name,
         message:   message)
     end

--- a/activemodel/test/cases/validations/i18n_validation_test.rb
+++ b/activemodel/test/cases/validations/i18n_validation_test.rb
@@ -42,6 +42,42 @@ class I18nValidationTest < ActiveModel::TestCase
     assert_equal ["Field Name empty"], @person.errors.full_messages
   end
 
+  def test_errors_full_messages_uses_attribute_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { person: { attributes: { name: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank")
+    assert_equal "Name test cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_model_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { person: { format: "%{message}" } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank")
+    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_deeply_nested_model_attributes_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { attributes: { street: { format: "%{message}" } } } } } })
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.street', "cannot be blank")
+    assert_equal "Contacts/addresses country cannot be blank", person.errors.full_message(:'contacts/addresses.country', "cannot be blank")
+  end
+
+  def test_errors_full_messages_uses_deeply_nested_model_model_format
+    I18n.backend.store_translations("en", activemodel: {
+      errors: { models: { 'person/contacts/addresses': { format: "%{message}" } } } } )
+
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.street', "cannot be blank")
+    assert_equal "cannot be blank", person.errors.full_message(:'contacts/addresses.country', "cannot be blank")
+  end
+
   # ActiveModel::Validations
 
   # A set of common cases for ActiveModel::Validations message generation that


### PR DESCRIPTION
WIP: Writing description and needs tests

### Summary

The goal of this PR is to make it easier for an app to transition from a `#{attribute} #{message}` to a `#{message}`, `full_message` error format.

`full_message` formats error messages with a `#{attribute} #{message}` format which generates error messages as “name cannot be nil”. 

It is possible to override the format with ``:"errors.format"`` but only language wide. https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L371 allows a language to define a custom format, but changing it forces to extract all messages, including the implicit ones as `:blank`

The `#{attribute} #{message}` format prevents languages to move the attribute name to somewhere within the message, for example, in some cases it can be preferred to have error messages as `“The person's name cannot be nil”`, so changing the format to `#{message}` and including the attribute name in the message itself can be preferable.

To make such transition easier, this PR allows to override `errors.format` at the attribute or model level, so an app can use either:

```
en:
  errors:
    format: '%{message}'
```

```
en:
  activemodel:
    errors:
      models:
        person:
          format: '%{message}'
```

```
en:
  activemodel:
    errors:
      models:
        person:
          attributes:
            name:
              format: '%{message}'
```

### How

This is based on `active_model/translation.rb#human_attribute_name`
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/translation.rb#L44


And `active_model/errors.rb#generate_message`
https://github.com/rails/rails/blob/master/activemodel/lib/active_model/errors.rb#L401
- The `@base.class.respond_to?(:i18n_scope)` is needed for cases where `ActiveModel::Errors` is used without including the `Translation` module

### Other Information

If there's anything else that's important and relevant to your pull
request, mention that information here. This could include
benchmarks, or other information.

If you are updating any of the CHANGELOG files or are asked to update the
CHANGELOG files by reviewers, please add the CHANGELOG entry at the top of the file.

Finally, if your pull request affects documentation or any non-code
changes, guidelines for those changes are [available
here](http://guides.rubyonrails.org/contributing_to_ruby_on_rails.html#contributing-to-the-rails-documentation)

Thanks for contributing to Rails!
