### PR TITLE
Faster path descendants check in ActiveSupport::EventedFileUpdateChecker

### DIFF
--- a/activesupport/lib/active_support/evented_file_update_checker.rb
+++ b/activesupport/lib/active_support/evented_file_update_checker.rb
@@ -207,9 +207,9 @@ module ActiveSupport
 
         private
           def ascendant_of?(base, other)
-            base != other && other.ascend do |ascendant|
-              break true if base == ascendant
-            end
+            base = base.to_s
+            base = "#{base}/" unless base[-1] == "/"
+            other.to_s.start_with?(base)
           end
       end
   end


### PR DESCRIPTION
### Summary

I noticed `ActiveSupport::EventedFileUpdateChecker#filter_out_descendants` was taking up a huge portion of boot time in core. I dug into the source of the problem and found the source of the problem in `ascendant_of?` because there are so many directories to check.

Instead of using Pathname#ascend, which iterates over all ascendants of the given path, we can just string compare the base and other. This is much faster and avoids scaling issues.

### Other Information

The entire `ActiveSupport::EventedFileUpdateChecker` class was rewritten in #40133, so this code would probably need to be reworked around that, but AFAICT the changes in that PR don't change the situation mentioned here since the rewrite still uses `ascend`. I didn't want to rewrite the fix around the new code without first confirming that this works against the current code.

I'm creating this first to discuss the problem and the solution here.