### PR TITLE
[Discussion]: Supporting #exists? in CPK

### DIFF
--- a/activerecord/lib/active_record/relation/finder_methods.rb
+++ b/activerecord/lib/active_record/relation/finder_methods.rb
@@ -323,7 +323,15 @@ module ActiveRecord
     #   Person.exists?(false)
     #   Person.exists?
     #   Person.where(name: 'Spartacus', rating: 4).exists?
-    def exists?(conditions = :none)
+    def exists?(*conditions)
+      if conditions.length.zero?
+        conditions = :none
+      elsif conditions.length == 1
+        conditions = conditions.pop
+      else
+        conditions = primary_key.zip(conditions).to_h
+      end
+
       if Base === conditions
         raise ArgumentError, <<-MSG.squish
           You are passing an instance of ActiveRecord::Base to `exists?`.

--- a/activerecord/test/cases/finder_test.rb
+++ b/activerecord/test/cases/finder_test.rb
@@ -25,6 +25,7 @@ require "models/subscriber"
 require "models/non_primary_key"
 require "models/clothing_item"
 require "models/cpk"
+require "models/sharded"
 require "support/stubs/strong_parameters"
 require "support/async_helper"
 
@@ -33,7 +34,8 @@ class FinderTest < ActiveRecord::TestCase
 
   fixtures :companies, :topics, :entrants, :developers, :developers_projects,
     :posts, :comments, :accounts, :authors, :author_addresses, :customers,
-    :categories, :categorizations, :cars, :clothing_items, :cpk_books
+    :categories, :categorizations, :cars, :clothing_items, :cpk_books,
+    :sharded_comments, :sharded_blog_posts, :sharded_tags, :sharded_blogs
 
   def test_find_by_id_with_hash
     assert_nothing_raised do
@@ -200,6 +202,14 @@ class FinderTest < ActiveRecord::TestCase
     assert_equal false, Topic.exists?(Topic.new.id)
 
     assert_raise(NoMethodError) { Topic.exists?([1, 2]) }
+  end
+
+  def test_exists_with_composite_primary_key
+    book = cpk_books(:cpk_great_author_first_book)
+
+    assert_equal true, Cpk::Book.exists?(*book.id)
+    assert_equal false, Cpk::Book.exists?(1, -1)
+    assert_raise(NoMethodError) { Topic.exists?(1, 2) }
   end
 
   def test_exists_with_scope


### PR DESCRIPTION
### What?

Let's explore API options for `exists?` within a CPK context.

As part of https://github.com/Shopify/rails-infra/issues/298, I uncovered the requirement to build support for `#exists?` on an Active Record model.

Currently, `#exists?` [supports the following API.](https://api.rubyonrails.org/v7.0.4.2/classes/ActiveRecord/FinderMethods.html#method-i-exists-3F):

```ruby
Person.exists?(5)
Person.exists?('5')
Person.exists?(['name LIKE ?', "%#{query}%"])
Person.exists?(id: [1, 4, 8])
Person.exists?(name: 'David')
Person.exists?(false)
Person.exists?
```

Notice, option (3) specifies an `Array` as the single argument, which then gets treated conditions of a WHERE-like query.

To bring support for models which have composite keys, there are a few options:

1. Modify the `exists?` signature to accept more than 1 argument. Any call with more than 1 argument treats all the arguments as part of a composite key. (Shown in this PR)

```ruby
Person.exists?('Paarth', 'Madan')
Person.exists?('Paarth', 'Madan', 123456789)
```

2. Accept a composite key as an `Array` as well (clashes with (3))

```ruby
Person.exists?(['Paarth', 'Madan'])
Person.exists?(['Paarth', 'Madan', 123456789])
```

This would require being able to distinguish intent from the "WHERE-like" syntax. This _could be done_ in a few ways, but they all seem problematic to me. For examples:
- Pattern matching
- Using whether the model has a composite primary key to deduce how it should be treated (ie. pick 1 API for the CPK case)
- "Type check" the arguments to see if they match the CPK

3. Don't directly support composite keys in `exists?`

There's other ways to check if a record exists. We don't _need_ to bring support directly to accepting a key.

Personally, option (2) seems to be most problematic because it involves inference. That makes things hard to reason about, and changing an API _based_ on whether a model is using a composite primary key seems indeterministic.

I'm mostly considering (1) and (3), but open to hearing other suggestions.

### Discussion Points

This is an important problem to start discussion around because the possibility of modifying public API is real. If we choose not to proceed with changing the API, it begs the question about our mental model with respect to how we solve these problems.

Some questions I'd love input on:

1. Is limited functionality acceptable for CPK?
2. If so, for how long?
3. Is it fair to _never_ bring support for `exists?` directly? What about other features?
4. If it's not, what will change in the future that will make this decision easier?
5. Is changing the API based on whether a model supports CPK too brittle?
6. How should this be handled in Rails releases? Is supporting a specific feature for CPK considered a bug-fix, or will this mandate a minor bump? Example: If we don't support `exists?` right now, but eventually choose to do it—will that make it in 7.1.x or 7.2?

Please share your thoughts!

cc: @Shopify/rails @nvasilevski @eileencodes 
