### PR TITLE
Introduce ractorize

### DIFF
--- a/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
+++ b/actionpack/lib/action_dispatch/journey/gtg/transition_table.rb
@@ -22,6 +22,18 @@ module ActionDispatch
           @memos           = Hash.new { |h, k| h[k] = [] }
         end
 
+        def freeze
+          return self if self.frozen?
+
+          @memos.default_proc = nil
+          @stdparam_states.freeze
+          @regexp_states.freeze
+          @string_states.freeze
+          @accepting.freeze
+          @memos.freeze
+          super
+        end
+
         def add_accepting(state)
           @accepting[state] = true
         end

--- a/activesupport/lib/active_support/key_generator.rb
+++ b/activesupport/lib/active_support/key_generator.rb
@@ -62,9 +62,21 @@ module ActiveSupport
       @cache_keys = Concurrent::Map.new
     end
 
+    def freeze
+      @key = "_caching_key_generator_#{object_id}".to_sym
+      Ractor[@key] = @cache_keys
+      @cache_keys = nil
+      super
+    end
+
     # Returns a derived key suitable for use.
     def generate_key(*args)
-      @cache_keys[args.join("|")] ||= @key_generator.generate_key(*args)
+      cache_keys[args.join("|")] ||= @key_generator.generate_key(*args)
     end
+
+    private
+      def cache_keys
+        @cache_keys || Ractor[@key] ||= Concurrent::Map.new
+      end
   end
 end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -127,6 +127,10 @@ module ActiveSupport
       super || @parent.key?(key)
     end
 
+    def keys
+      @parent.keys | super
+    end
+
     def overridden?(key)
       !!(@parent && @parent.key?(key) && own_key?(key.to_sym))
     end

--- a/activesupport/lib/active_support/ordered_options.rb
+++ b/activesupport/lib/active_support/ordered_options.rb
@@ -100,6 +100,16 @@ module ActiveSupport
       end
     end
 
+    def freeze
+      return self if frozen?
+
+      @own_keys = own_keys.dup.freeze
+      self.default_proc = nil
+      @parent.freeze
+      replace(to_h)
+      super
+    end
+
     def to_h
       @parent.to_h.merge(self)
     end
@@ -120,12 +130,12 @@ module ActiveSupport
       pp.pp_hash(to_h)
     end
 
-    alias_method :own_key?, :key?
-    private :own_key?
-
     def key?(key)
       super || @parent.key?(key)
     end
+
+    alias_method :_own_keys, :keys
+    private :_own_keys
 
     def keys
       @parent.keys | super
@@ -147,5 +157,14 @@ module ActiveSupport
       to_h.each(&block)
       self
     end
+
+    private
+      def own_key?(key)
+        own_keys.include?(key.to_sym)
+      end
+
+      def own_keys
+        @own_keys || _own_keys
+      end
   end
 end

--- a/activesupport/lib/active_support/testing/ractors_assertions.rb
+++ b/activesupport/lib/active_support/testing/ractors_assertions.rb
@@ -5,6 +5,18 @@ module ActiveSupport
     module RactorsAssertions # :nodoc: all
       private
         if RUBY_VERSION >= "4.0"
+          def on_ractor(*args, &block)
+            block = Ractor.shareable_proc(&block)
+
+            port = Ractor::Port.new
+
+            Ractor.new(port, block, args) do |port, block, args|
+              port.send block.call(*args)
+            end.join
+
+            port.receive
+          end
+
           def assert_ractor_make_shareable(obj)
             assert_nothing_raised { Ractor.make_shareable(obj) }
           end
@@ -13,6 +25,10 @@ module ActiveSupport
             assert Ractor.shareable?(obj), "Expected #{obj.inspect} to be shareable, but it is not."
           end
         else
+          def on_ractor(*args)
+            yield(*args)
+          end
+
           def assert_ractor_make_shareable(obj)
             assert true
           end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -2,6 +2,7 @@
 
 require_relative "abstract_unit"
 require "active_support/testing/ractors_assertions"
+require "active_support/testing/isolation"
 
 begin
   require "openssl"
@@ -67,8 +68,6 @@ else
   end
 
   class CachingKeyGeneratorTest < ActiveSupport::TestCase
-    include ActiveSupport::Testing::RactorsAssertions
-
     def setup
       @secret    = SecureRandom.hex(64)
       @generator = ActiveSupport::KeyGenerator.new(@secret, iterations: 2)
@@ -103,6 +102,14 @@ else
 
       assert_not_equal derived_key, different_length_key
     end
+  end
+
+  class RactorKeyGeneratorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::Isolation
+    include ActiveSupport::Testing::RactorsAssertions
+
+    # This test has to be isolated due to a bug with Ractors on 4.0.5. We can move it back with the other
+    # tests once 4.0.6 is released.
 
     test "CachingKeyGenerator can work across ractors" do
       # OpenSSL::Digest are not Ractor-safe, but the fix is already merged upstream. This test can be updated

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -100,5 +100,25 @@ else
 
       assert_not_equal derived_key, different_length_key
     end
+
+    test "CachingKeyGenerator can work across ractors" do
+      # OpenSSL::Digest are not Ractor-safe, but the fix is already merged upstream. This test can be updated
+      # to use our implementation once a version of Ruby ships with ruby/openssl@502bc6c
+      key_generator = Class.new(ActiveSupport::KeyGenerator) do
+        def generate_key(salt, key_size)
+          OpenSSL::PKCS5.pbkdf2_hmac(@secret, salt, @iterations, key_size, "SHA1")
+        end
+      end.new("foo", iterations: 2)
+      caching_generator = ActiveSupport::CachingKeyGenerator.new(key_generator)
+      ActiveSupport::Ractors.make_shareable(caching_generator)
+
+      port = Ractor::Port.new
+      Ractor.new(port, caching_generator) do |port, caching_generator|
+        port.send caching_generator.generate_key("some_salt", 32)
+      end.join
+      key = port.receive
+
+      assert_equal key, caching_generator.generate_key("some_salt", 32)
+    end
   end
 end

--- a/activesupport/test/key_generator_test.rb
+++ b/activesupport/test/key_generator_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "abstract_unit"
+require "active_support/testing/ractors_assertions"
 
 begin
   require "openssl"
@@ -66,6 +67,8 @@ else
   end
 
   class CachingKeyGeneratorTest < ActiveSupport::TestCase
+    include ActiveSupport::Testing::RactorsAssertions
+
     def setup
       @secret    = SecureRandom.hex(64)
       @generator = ActiveSupport::KeyGenerator.new(@secret, iterations: 2)
@@ -112,11 +115,9 @@ else
       caching_generator = ActiveSupport::CachingKeyGenerator.new(key_generator)
       ActiveSupport::Ractors.make_shareable(caching_generator)
 
-      port = Ractor::Port.new
-      Ractor.new(port, caching_generator) do |port, caching_generator|
-        port.send caching_generator.generate_key("some_salt", 32)
-      end.join
-      key = port.receive
+      key = on_ractor(caching_generator) do |caching_generator|
+        caching_generator.generate_key("some_salt", 32)
+      end
 
       assert_equal key, caching_generator.generate_key("some_salt", 32)
     end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -3,8 +3,11 @@
 require "pp"
 require_relative "abstract_unit"
 require "active_support/ordered_options"
+require "active_support/testing/ractors_assertions"
 
 class OrderedOptionsTest < ActiveSupport::TestCase
+  include ActiveSupport::Testing::RactorsAssertions
+
   def test_usage
     a = ActiveSupport::OrderedOptions.new
 
@@ -354,5 +357,29 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     io = StringIO.new
     PP.pp(object, io)
     assert_equal({ one: "first value", two: "second value", three: "third value" }.inspect, io.string.strip)
+  end
+
+  def test_inheritable_options_ractor_shareable
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_ractor_make_shareable(object)
+
+    assert_equal "first value", object[:one]
+    assert_equal "second value", object[:two]
+    assert_equal "third value", object[:three]
+  end
+
+  def test_overridden_works_when_frozen
+    object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    object.freeze
+
+    assert object.overridden?(:two)
+    assert_not object.overridden?(:one)
+    assert_not object.overridden?(:three)
   end
 end

--- a/activesupport/test/ordered_options_test.rb
+++ b/activesupport/test/ordered_options_test.rb
@@ -250,6 +250,14 @@ class OrderedOptionsTest < ActiveSupport::TestCase
     assert_not object.key?(:four)
   end
 
+  def test_inheritable_options_keys
+    object = ActiveSupport::InheritableOptions.new(one: "first value")
+    object[:two] = "second value"
+    object["three"] = "third value"
+
+    assert_equal [:one, :two, :three], object.keys
+  end
+
   def test_inheritable_options_overridden
     object = ActiveSupport::InheritableOptions.new(one: "first value", two: "second value", three: "third value")
     object["one"] = "first value override"

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -772,7 +772,7 @@ module Rails
       end
 
       def coerce_same_site_protection(protection)
-        protection.respond_to?(:call) ? protection : proc { protection }
+        protection.respond_to?(:call) ? protection : ActiveSupport::Ractors.shareable_proc { protection }
       end
 
       def filter_parameters

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -668,6 +668,17 @@ module Rails
       Rails.autoloaders.each(&:eager_load)
     end
 
+    def ractorize! # :nodoc:
+      warn "WARNING: Rails' Ractor support is experimental. Don't try this at home!", category: :experimental, uplevel: 1
+
+      env_config
+      routes
+
+      @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
+
+      Ractor.make_shareable(self)
+    end
+
   protected
     alias :build_middleware_stack :app
 

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -215,9 +215,9 @@ module Rails
     #
     def message_verifiers
       @message_verifiers ||=
-        ActiveSupport::MessageVerifiers.new do |salt, secret_key_base: self.secret_key_base|
-          key_generator(secret_key_base).generate_key(salt)
-        end.rotate_defaults
+        ActiveSupport::MessageVerifiers.new(&ActiveSupport::Ractors.shareable_proc do |salt, secret_key_base: Rails.application.secret_key_base|
+          Rails.application.key_generator(secret_key_base).generate_key(salt)
+        end).rotate_defaults
     end
 
     # Returns a message verifier object.

--- a/railties/lib/rails/application.rb
+++ b/railties/lib/rails/application.rb
@@ -677,6 +677,10 @@ module Rails
       @autoloaders, @reloaders, @routes_reloader = nil, nil, nil
 
       Ractor.make_shareable(self)
+
+      Ractor.make_shareable(Rails.event)
+      Ractor.make_shareable(Rails.error)
+      Ractor.make_shareable(Rails.backtrace_cleaner)
     end
 
   protected

--- a/railties/lib/rails/configuration.rb
+++ b/railties/lib/rails/configuration.rb
@@ -116,9 +116,25 @@ module Rails
         @after_generate_callbacks = []
       end
 
+      def freeze
+        return self if self.frozen?
+
+        @aliases.default_proc = nil
+        @options.default_proc = nil
+        @aliases.freeze
+        @options.freeze
+        @fallbacks.freeze
+        @templates.freeze
+        @hidden_namespaces.freeze
+        @after_generate_callbacks.freeze
+        super
+      end
+
       def initialize_copy(source)
         @aliases = @aliases.deep_dup
+        @aliases.default_proc = ->(h, k) { h[k] = {} }
         @options = @options.deep_dup
+        @options.default_proc = ->(h, k) { h[k] = {} }
         @fallbacks = @fallbacks.deep_dup
         @templates = @templates.dup
       end

--- a/railties/lib/rails/engine.rb
+++ b/railties/lib/rails/engine.rb
@@ -448,6 +448,12 @@ module Rails
       super
     end
 
+    def freeze
+      app
+      @app_build_lock = nil
+      super
+    end
+
     # Load console and invoke the registered hooks.
     # Check Rails::Railtie.console for more info.
     def load_console(app = self)

--- a/railties/lib/rails/initializable.rb
+++ b/railties/lib/rails/initializable.rb
@@ -47,6 +47,17 @@ module Rails
         concat(initializers) if initializers
       end
 
+      def freeze
+        return self if self.frozen?
+
+        @order.default_proc = nil
+        @resolve.default_proc = nil
+        @order.freeze
+        @resolve.freeze
+        @collection.freeze
+        super
+      end
+
       def to_a
         @collection
       end

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "isolation/abstract_unit"
+require "active_support/testing/ractors_assertions"
+
+if RUBY_VERSION >= "4.0"
+  module ApplicationTests
+    class RactorsTest < ActiveSupport::TestCase
+      include ActiveSupport::Testing::Isolation
+      include ActiveSupport::Testing::RactorsAssertions
+
+      def setup
+        build_app
+
+        add_to_env_config "production", "ActiveSupport::Ractors.unshareable_proc_action = :raise"
+
+        # Remove some defaults that are not compatible
+        add_to_env_config "production", "config.logger = ActiveSupport::Logger.new(nil)"
+        add_to_env_config "production", "config.public_file_server.enabled = false"
+        add_to_env_config "production", "config.cache_store = :null_store"
+        add_to_env_config "production", "config.action_cable.mount_path = nil"
+      end
+
+      def teardown
+        teardown_app
+      end
+
+      test "ractorize! makes the app shareable in production mode" do
+        app "production"
+
+        Rails.application.ractorize!
+
+        assert_ractor_shareable Rails.application
+      end
+    end
+  end
+end

--- a/railties/test/application/ractors_test.rb
+++ b/railties/test/application/ractors_test.rb
@@ -31,6 +31,9 @@ if RUBY_VERSION >= "4.0"
         Rails.application.ractorize!
 
         assert_ractor_shareable Rails.application
+        assert_ractor_shareable Rails.event
+        assert_ractor_shareable Rails.error
+        assert_ractor_shareable Rails.backtrace_cleaner
       end
     end
   end

--- a/tools/strict_warnings.rb
+++ b/tools/strict_warnings.rb
@@ -14,6 +14,8 @@ module RailsStrictWarnings # :nodoc:
     # Expected non-verbose warning emitted by Rails.
     /Ignoring .*\.yml because it has expired/,
     /Failed to validate the schema cache because/,
+    /Rails' Ractor support is experimental/,
+    /Ractor API is experimental and may change in future versions of Ruby/,
   )
 
   SUPPRESSED_WARNINGS = Regexp.union(


### PR DESCRIPTION
This PR contains the rest of the work to make a fresh Rails application ractor shareable.

We introduce the `ractorize!` method which prepares the application to be frozen then calls `Ractor.make_shareable(self)`. After this the application can be shared in non-main Ractors to do interesting things like serve requests.

There are a few constraints:
- the application must be eager loaded, no autoloading and no reloading
- ditto for routes
- no action cable
- no solid cache store
- no rack file server (this is fixed in rack but we need a new version cut - and I have a few more rack fixes to push first)

This PR contains a few fixes that make ractorization work:
- The app's key generator is now ractor local (if the app has opted in to ractors). This contains a concurrent map which is not Ractor-shareable. Ractor-safe hashes are still in development, so this is a pragmatic choice for the time being.
- Engines' app must be initialized at freezing time so we can drop the mutex used to control building it
- A number of hash default procs which mutate the hash are inherently not shareable. Those hashes are fully built at sharing time, so we can then drop the default proc.

I put those fixes on individual commits so they're easier to review. We could upstream them separately, though it might be clearer to include them all in one PR.