### PR TITLE
Refactor how details are handled for template selection

### DIFF
--- a/actionmailer/lib/action_mailer.rb
+++ b/actionmailer/lib/action_mailer.rb
@@ -107,5 +107,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
-  ActionView::LookupContext::DetailsKey.clear
+  ActionView::LookupContext.clear
 end

--- a/actionpack/lib/action_controller/metal/implicit_render.rb
+++ b/actionpack/lib/action_controller/metal/implicit_render.rb
@@ -35,8 +35,9 @@ module ActionController
     include BasicImplicitRender
 
     def default_render
-      if template_exists?(action_name.to_s, _prefixes, variants: request.variant)
-        render
+      lookup_context.variants = request.variant if request.variant.present?
+      if (template = lookup_context.find(action_name.to_s, _prefixes))
+        render(template: template)
       elsif any_templates?(action_name.to_s, _prefixes)
         message = "#{self.class.name}\##{action_name} is missing a template " \
           "for this request format and variant.\n" \

--- a/actionpack/lib/action_dispatch.rb
+++ b/actionpack/lib/action_dispatch.rb
@@ -163,5 +163,5 @@ autoload :Mime, "action_dispatch/http/mime_type"
 ActiveSupport.on_load(:action_view) do
   ActionView::Base.default_formats ||= Mime.symbols
   ActionView::Template.mime_types_implementation = Mime
-  ActionView::LookupContext::DetailsKey.clear
+  ActionView::LookupContext.clear
 end

--- a/actionpack/test/controller/mime/respond_to_test.rb
+++ b/actionpack/test/controller/mime/respond_to_test.rb
@@ -336,7 +336,7 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.register("text/x-mobile", :mobile)
     Mime::Type.register("application/fancy-xml", :fancy_xml)
     Mime::Type.register("text/html; fragment", :html_fragment)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def teardown
@@ -345,7 +345,7 @@ class RespondToControllerTest < ActionController::TestCase
     Mime::Type.unregister(:mobile)
     Mime::Type.unregister(:fancy_xml)
     Mime::Type.unregister(:html_fragment)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_html_fragment

--- a/actionpack/test/controller/render_test.rb
+++ b/actionpack/test/controller/render_test.rb
@@ -354,11 +354,11 @@ module TemplateModificationHelper
       key = name + ".erb"
       original = hash[key]
       hash[key] = "#{original} Modified!"
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
       yield
     ensure
       hash[key] = original
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
     end
 end
 

--- a/actionview/lib/action_view/cache_expiry.rb
+++ b/actionview/lib/action_view/cache_expiry.rb
@@ -52,7 +52,7 @@ module ActionView
 
       private
         def reload!
-          ActionView::LookupContext::DetailsKey.clear
+          ActionView::LookupContext.clear
         end
 
         def build_watcher

--- a/actionview/lib/action_view/digestor.rb
+++ b/actionview/lib/action_view/digestor.rb
@@ -1,12 +1,26 @@
 # frozen_string_literal: true
 
+require "concurrent/map"
 require "action_view/dependency_tracker"
 
 module ActionView
   class Digestor
     @@digest_mutex = Mutex.new
+    @cache = Concurrent::Map.new
 
     class << self
+      def cache(details_key)
+        @cache[details_key] ||= Concurrent::Map.new
+      end
+
+      def digest_caches
+        @cache.values
+      end
+
+      def clear_cache
+        @cache.clear
+      end
+
       # Supported options:
       #
       # * <tt>name</tt>         - Template name

--- a/actionview/lib/action_view/layouts.rb
+++ b/actionview/lib/action_view/layouts.rb
@@ -284,7 +284,7 @@ module ActionView
         silence_redefinition_of_method(:_layout)
 
         prefixes = /\blayouts/.match?(_implied_layout_name) ? [] : ["layouts"]
-        default_behavior = "lookup_context.find('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, { formats: formats }) || super"
+        default_behavior = "lookup_context.find('#{_implied_layout_name}', #{prefixes.inspect}, false, keys, lookup_context.details_for(formats: formats)) || super"
         name_clause = if name
           default_behavior
         else

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,7 +107,7 @@ module ActionView
       end
 
       def digest_cache
-        @digest_cache ||= DetailsKey.digest_cache(to_h)
+        @digest_cache ||= DetailsKey.digest_cache(to_cache_key)
       end
 
       def merge(options)
@@ -154,6 +154,10 @@ module ActionView
             rank(variants, value)
           end
         end
+
+        def to_cache_key
+          [locale, Template.normalized_formats(formats) || formats, variants, handlers].freeze
+        end
     end
 
     class DetailsKey # :nodoc:
@@ -162,8 +166,8 @@ module ActionView
       @details_keys = Concurrent::Map.new
       @digest_cache = Concurrent::Map.new
 
-      def self.digest_cache(details)
-        @digest_cache[details_cache_key(details)] ||= Concurrent::Map.new
+      def self.digest_cache(key)
+        @digest_cache[key] ||= Concurrent::Map.new
       end
 
       def self.details_cache_key(details)

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,7 +107,7 @@ module ActionView
       end
 
       def digest_cache
-        @digest_cache ||= DetailsKey.digest_cache(to_cache_key)
+        @digest_cache ||= Digestor.cache(to_cache_key)
       end
 
       def merge(options)
@@ -164,11 +164,6 @@ module ActionView
       alias :eql? :equal?
 
       @details_keys = Concurrent::Map.new
-      @digest_cache = Concurrent::Map.new
-
-      def self.digest_cache(key)
-        @digest_cache[key] ||= Concurrent::Map.new
-      end
 
       def self.details_cache_key(details)
         @details_keys.fetch(details) do
@@ -188,11 +183,7 @@ module ActionView
         end
         ActionView::LookupContext.reset_view_context_class
         @details_keys.clear
-        @digest_cache.clear
-      end
-
-      def self.digest_caches
-        @digest_cache.values
+        Digestor.clear_cache
       end
     end
 

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -19,6 +19,12 @@ module ActionView
       [:locale, :formats, :variants, :handlers]
     end
 
+    def self.clear
+      ActionView::PathRegistry.all_resolvers.each(&:clear_cache)
+      reset_view_context_class
+      Digestor.clear_cache
+    end
+
     class Details
       def initialize(locale: nil, formats: nil, variants: nil, handlers: nil)
         @locale   = locale   && Array(locale)
@@ -158,16 +164,6 @@ module ActionView
         def to_cache_key
           [locale, Template.normalized_formats(formats) || formats, variants, handlers].freeze
         end
-    end
-
-    class DetailsKey # :nodoc:
-      def self.clear
-        ActionView::PathRegistry.all_resolvers.each do |resolver|
-          resolver.clear_cache
-        end
-        ActionView::LookupContext.reset_view_context_class
-        Digestor.clear_cache
-      end
     end
 
     def self.reset_view_context_class

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,10 +15,6 @@ module ActionView
   class LookupContext # :nodoc:
     attr_accessor :prefixes
 
-    def self.registered_details
-      [:locale, :formats, :variants, :handlers]
-    end
-
     def self.clear
       ActionView::PathRegistry.all_resolvers.each(&:clear_cache)
       reset_view_context_class
@@ -184,35 +180,36 @@ module ActionView
     module ViewPaths
       attr_reader :view_paths
 
-      def find(name, prefixes = [], partial = false, keys = [], options = {})
+      def find(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find(name, prefixes, partial, details, @cache, keys)
       end
 
-      def find!(name, prefixes = [], partial = false, keys = [], options = {})
+      def find!(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find!(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find!(name, prefixes, partial, details, @cache, keys)
       end
 
-      def find_all(name, prefixes = [], partial = false, keys = [], options = {})
+      def find_all(name, prefixes = [], partial = false, keys = [], details = @details)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.find_all(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.find_all(name, prefixes, partial, details, @cache, keys)
       end
 
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.exists?(name, prefixes, partial, detail_args_for(options), @cache, keys)
+        @view_paths.exists?(name, prefixes, partial, details_for(options), @cache, keys)
       end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)
         name, prefixes = normalize_name(name, prefixes)
-        @view_paths.exists?(name, prefixes, partial, detail_args_for_any, @cache, [])
+        @view_paths.exists?(name, prefixes, partial, details_for_any, @cache, [])
       end
       alias :any_templates? :any?
 
-      def any_formats?(name, prefixes = [], partial = false, keys = [], options = {})
-        exists?(name, prefixes, partial, keys, **options, formats: default_formats)
+      def any_formats?(name, prefixes = [], partial = false, keys = [], details = @details)
+        name, prefixes = normalize_name(name, prefixes)
+        @view_paths.exists?(name, prefixes, partial, details.merge(formats: default_formats), @cache, keys)
       end
 
       def append_view_paths(paths)
@@ -221,6 +218,15 @@ module ActionView
 
       def prepend_view_paths(paths)
         @view_paths = build_view_paths(paths + @view_paths.to_a)
+      end
+
+      # Resolves the Details to look up with from the render options (e.g.
+      # <tt>formats: :json</tt> passed to #render): the context's own Details
+      # when there are no relevant overrides, otherwise a copy with them layered
+      # on. Renderers call this once and then flow the resulting Details straight
+      # through find/find_all.
+      def details_for(options)
+        @details.merge(options)
       end
 
     private
@@ -234,14 +240,8 @@ module ActionView
         end
       end
 
-      # Compute details hash and key according to user options (e.g. passed from #render).
-      def detail_args_for(options) # :doc:
-        return @details if options.empty? # most common path.
-        @details.merge(options)
-      end
-
-      def detail_args_for_any
-        @detail_args_for_any ||= Details.new(variants: :any)
+      def details_for_any
+        @details_for_any ||= Details.new(variants: :any)
       end
 
       # Fix when prefix is specified as part of the template name

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -15,43 +15,121 @@ module ActionView
   class LookupContext # :nodoc:
     attr_accessor :prefixes
 
-    singleton_class.attr_accessor :default_procs
-    self.default_procs = {}.freeze
-
     def self.registered_details
-      self.default_procs.keys
+      [:locale, :formats, :variants, :handlers]
     end
 
-    def self.register_detail(name, &block)
-      self.default_procs = self.default_procs.merge(name => block).freeze
+    class Details
+      def initialize(locale: nil, formats: nil, variants: nil, handlers: nil)
+        @locale   = locale   && Array(locale)
+        @formats  = formats  && Array(formats)
+        @variants = variants == :any ? :any : variants && Array(variants)
+        @handlers = handlers && Array(handlers)
+      end
 
-      Accessors.define_method(:"default_#{name}", &block)
-      Accessors.module_eval <<-METHOD, __FILE__, __LINE__ + 1
-        def #{name}
-          @details[:#{name}] || []
+      attr_reader :html_fallback_for_js
+
+      def locale
+        @locale ||= default_locale
+      end
+
+      def locale=(value)
+        value = value.present? ? Array(value) : default_locale
+        return if value == @locale
+        @locale = value
+        @digest_cache = nil
+      end
+
+      def formats
+        @formats ||= default_formats
+      end
+
+      def formats=(values)
+        if values
+          values = values.dup
+          values.concat(default_formats) if values.delete "*/*"
+          values.uniq!
+
+          Template.validate_formats(values)
+
+          if (values.length == 1) && (values[0] == :js)
+            values << :html
+            @html_fallback_for_js = true
+          end
         end
 
-        def #{name}=(value)
-          value = value.present? ? Array(value) : default_#{name}
-          _set_detail(:#{name}, value) if value != @details[:#{name}]
+        values = values.presence || default_formats
+        return if values == @formats
+        @formats = values
+        @digest_cache = nil
+      end
+
+      def variants
+        @variants ||= default_variants
+      end
+
+      def variants=(value)
+        value = value.present? ? Array(value) : default_variants
+        return if value == @variants
+        @variants = value
+        @digest_cache = nil
+      end
+
+      def handlers
+        @handlers ||= default_handlers
+      end
+
+      def handlers=(value)
+        value = value.present? ? Array(value) : default_handlers
+        return if value == @handlers
+        @handlers = value
+        @digest_cache = nil
+      end
+
+      def default_locale
+        locales = [I18n.locale]
+        locales.concat(I18n.fallbacks[I18n.locale]) if I18n.respond_to? :fallbacks
+        locales << I18n.default_locale
+        locales.uniq!
+        locales
+      end
+
+      def default_formats
+        ActionView::Base.default_formats || [:html, :text, :js, :css, :xml, :json]
+      end
+
+      def default_variants
+        []
+      end
+
+      def default_handlers
+        Template::Handlers.extensions
+      end
+
+      def digest_cache
+        @digest_cache ||= DetailsKey.digest_cache(to_h)
+      end
+
+      def merge(options)
+        return self if [:locale, :formats, :variants, :handlers].freeze.none? { |key| options[key] }
+        self.class.new(
+          locale:   options[:locale]   || locale,
+          formats:  options[:formats]  || formats,
+          variants: options[:variants] || variants,
+          handlers: options[:handlers] || handlers,
+        )
+      end
+
+      def to_h
+        { locale: locale, formats: formats, variants: variants, handlers: handlers }
+      end
+
+      private
+        def initialize_copy(other)
+          @digest_cache = nil
+          super
         end
-      METHOD
     end
-
-    # Holds accessors for the registered details.
-    module Accessors # :nodoc:
-    end
-
-    register_detail(:locale) do
-      locales = [I18n.locale]
-      locales.concat(I18n.fallbacks[I18n.locale]) if I18n.respond_to? :fallbacks
-      locales << I18n.default_locale
-      locales.uniq!
-      locales
-    end
-    register_detail(:formats) { ActionView::Base.default_formats || [:html, :text, :js, :css,  :xml, :json] }
-    register_detail(:variants) { [] }
-    register_detail(:handlers) { Template::Handlers.extensions }
 
     class DetailsKey # :nodoc:
       alias :eql? :equal?
@@ -103,28 +181,9 @@ module ActionView
     @view_context_mutex = Mutex.new
     ActiveSupport.on_load(:action_view) { ActionView::LookupContext.view_context_class }
 
-    # Add caching behavior on top of Details.
-    module DetailsCache
-      attr_accessor :cache
-
-      def disable_cache
-        old_value, @cache = @cache, false
-        yield
-      ensure
-        @cache = old_value
-      end
-
-    private
-      def _set_detail(key, value) # :doc:
-        @details = @details.dup if @digest_cache
-        @digest_cache = nil
-        @details[key] = value
-      end
-    end
-
     # Helpers related to template lookup using the lookup context information.
     module ViewPaths
-      attr_reader :view_paths, :html_fallback_for_js
+      attr_reader :view_paths
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
@@ -178,24 +237,12 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details if options.empty? # most common path.
-        @details.merge(options)
+        return @details.to_h if options.empty? # most common path.
+        @details.merge(options).to_h
       end
 
       def detail_args_for_any
-        @detail_args_for_any ||= begin
-          details = {}
-
-          LookupContext.registered_details.each do |k|
-            if k == :variants
-              details[k] = :any
-            else
-              details[k] = LookupContext.default_procs[k].call
-            end
-          end
-
-          details
-        end
+        @detail_args_for_any ||= Details.new(variants: :any).to_h
       end
 
       # Fix when prefix is specified as part of the template name
@@ -218,59 +265,52 @@ module ActionView
       end
     end
 
-    include Accessors
-    include DetailsCache
     include ViewPaths
 
+    attr_accessor :cache
+
     def initialize(view_paths, details = {}, prefixes = [])
-      @digest_cache = nil
+      # Load ActionView::Base so its on_load(:action_view) hooks run before we
+      # resolve any templates (e.g. template handler registration).
+      _ = ActionView::Base
       @cache = true
       @prefixes = prefixes
 
-      @details = initialize_details({}, details)
+      @details = if details.is_a?(Details)
+        details
+      else
+        Details.new(
+          locale:   details[:locale],
+          formats:  details[:formats],
+          variants: details[:variants],
+          handlers: details[:handlers],
+        )
+      end
+
+
       @view_paths = build_view_paths(view_paths)
     end
 
-    def digest_cache
-      @digest_cache ||= DetailsKey.digest_cache(@details)
+    delegate :formats, :formats=, :variants, :variants=, :handlers, :handlers=,
+             :html_fallback_for_js, :default_formats, :digest_cache, to: :@details
+
+    def disable_cache
+      old_value, @cache = @cache, false
+      yield
+    ensure
+      @cache = old_value
     end
 
     def with_prepended_formats(formats)
       details = @details.dup
-      details[:formats] = formats
+      details.formats = formats
 
       self.class.new(@view_paths, details, @prefixes)
     end
 
-    def initialize_details(target, details)
-      LookupContext.registered_details.each do |k|
-        target[k] = details[k] || LookupContext.default_procs[k].call
-      end
-      target
-    end
-    private :initialize_details
-
-    # Override formats= to expand ["*/*"] values and automatically
-    # add :html as fallback to :js.
-    def formats=(values)
-      if values
-        values = values.dup
-        values.concat(default_formats) if values.delete "*/*"
-        values.uniq!
-
-        Template.validate_formats(values)
-
-        if (values.length == 1) && (values[0] == :js)
-          values << :html
-          @html_fallback_for_js = true
-        end
-      end
-      super(values)
-    end
-
     # Override locale to return a symbol instead of array.
     def locale
-      @details[:locale].first
+      @details.locale.first
     end
 
     # Overload locale= to also set the I18n.locale. If the current I18n.config object responds
@@ -282,7 +322,7 @@ module ActionView
         config.locale = value
       end
 
-      super(default_locale)
+      @details.locale = @details.default_locale
     end
   end
 end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -161,28 +161,11 @@ module ActionView
     end
 
     class DetailsKey # :nodoc:
-      alias :eql? :equal?
-
-      @details_keys = Concurrent::Map.new
-
-      def self.details_cache_key(details)
-        @details_keys.fetch(details) do
-          if formats = details[:formats]
-            if normalized = Template.normalized_formats(formats)
-              details = details.dup
-              details[:formats] = normalized
-            end
-          end
-          @details_keys[details] ||= TemplateDetails::Requested.new(**details)
-        end
-      end
-
       def self.clear
         ActionView::PathRegistry.all_resolvers.each do |resolver|
           resolver.clear_cache
         end
         ActionView::LookupContext.reset_view_context_class
-        @details_keys.clear
         Digestor.clear_cache
       end
     end

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -120,6 +120,15 @@ module ActionView
         )
       end
 
+      def template_rank(template)
+        d = template.details
+        format  = rank(formats, d.format)     or return
+        locale  = rank(self.locale, d.locale) or return
+        variant = variant_rank(d.variant)     or return
+        handler = rank(handlers, d.handler)   or return
+        [format, locale, variant, handler]
+      end
+
       def to_h
         { locale: locale, formats: formats, variants: variants, handlers: handlers }
       end
@@ -128,6 +137,22 @@ module ActionView
         def initialize_copy(other)
           @digest_cache = nil
           super
+        end
+
+        def rank(requested, value)
+          if requested
+            requested.index(value) || (requested.size if value.nil?)
+          elsif value.nil?
+            0
+          end
+        end
+
+        def variant_rank(value)
+          if variants == :any
+            value.nil? ? 0 : 1
+          else
+            rank(variants, value)
+          end
         end
     end
 
@@ -237,12 +262,12 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details.to_h if options.empty? # most common path.
-        @details.merge(options).to_h
+        return @details if options.empty? # most common path.
+        @details.merge(options)
       end
 
       def detail_args_for_any
-        @detail_args_for_any ||= Details.new(variants: :any).to_h
+        @detail_args_for_any ||= Details.new(variants: :any)
       end
 
       # Fix when prefix is specified as part of the template name

--- a/actionview/lib/action_view/lookup_context.rb
+++ b/actionview/lib/action_view/lookup_context.rb
@@ -107,13 +107,6 @@ module ActionView
     module DetailsCache
       attr_accessor :cache
 
-      # Calculate the details key. Remove the handlers from calculation to improve performance
-      # since the user cannot modify it explicitly.
-      def details_key # :nodoc:
-        @details_key ||= DetailsKey.details_cache_key(@details) if @cache
-      end
-
-      # Temporary skip passing the details_key forward.
       def disable_cache
         old_value, @cache = @cache, false
         yield
@@ -123,9 +116,8 @@ module ActionView
 
     private
       def _set_detail(key, value) # :doc:
-        @details = @details.dup if @digest_cache || @details_key
+        @details = @details.dup if @digest_cache
         @digest_cache = nil
-        @details_key = nil
         @details[key] = value
       end
     end
@@ -136,33 +128,28 @@ module ActionView
 
       def find(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def find!(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find!(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find!(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def find_all(name, prefixes = [], partial = false, keys = [], options = {})
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.find_all(name, prefixes, partial, details, details_key, keys)
+        @view_paths.find_all(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
 
       def exists?(name, prefixes = [], partial = false, keys = [], **options)
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for(options)
-        @view_paths.exists?(name, prefixes, partial, details, details_key, keys)
+        @view_paths.exists?(name, prefixes, partial, detail_args_for(options), @cache, keys)
       end
       alias :template_exists? :exists?
 
       def any?(name, prefixes = [], partial = false)
         name, prefixes = normalize_name(name, prefixes)
-        details, details_key = detail_args_for_any
-        @view_paths.exists?(name, prefixes, partial, details, details_key, [])
+        @view_paths.exists?(name, prefixes, partial, detail_args_for_any, @cache, [])
       end
       alias :any_templates? :any?
 
@@ -191,16 +178,8 @@ module ActionView
 
       # Compute details hash and key according to user options (e.g. passed from #render).
       def detail_args_for(options) # :doc:
-        return @details, details_key if options.empty? # most common path.
-        user_details = @details.merge(options)
-
-        if @cache
-          details_key = DetailsKey.details_cache_key(user_details)
-        else
-          details_key = nil
-        end
-
-        [user_details, details_key]
+        return @details if options.empty? # most common path.
+        @details.merge(options)
       end
 
       def detail_args_for_any
@@ -215,11 +194,7 @@ module ActionView
             end
           end
 
-          if @cache
-            [details, DetailsKey.details_cache_key(details)]
-          else
-            [details, nil]
-          end
+          details
         end
       end
 
@@ -248,7 +223,6 @@ module ActionView
     include ViewPaths
 
     def initialize(view_paths, details = {}, prefixes = [])
-      @details_key = nil
       @digest_cache = nil
       @cache = true
       @prefixes = prefixes

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -38,12 +38,16 @@ module ActionView # :nodoc:
     end
 
     def find(path, prefixes, partial, details, cache, locals)
-      find_all(path, prefixes, partial, details, cache, locals).first
+      search_combinations(prefixes) do |resolver, prefix|
+        template = resolver.find(path, prefix, partial, details, cache, locals)
+        return template if template
+      end
+      nil
     end
 
     def find!(path, prefixes, partial, details, cache, locals)
       find(path, prefixes, partial, details, cache, locals) ||
-        raise(MissingTemplate.new(self, path, prefixes, partial, details, cache, locals))
+        raise(MissingTemplate.new(self, path, prefixes, partial, details.to_h, cache, locals))
     end
 
     def find_all(path, prefixes, partial, details, cache, locals)

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -37,25 +37,25 @@ module ActionView # :nodoc:
       PathSet.new(paths + array)
     end
 
-    def find(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).first
+    def find(path, prefixes, partial, details, cache, locals)
+      find_all(path, prefixes, partial, details, cache, locals).first
     end
 
-    def find!(path, prefixes, partial, details, details_key, locals)
-      find(path, prefixes, partial, details, details_key, locals) ||
-        raise(MissingTemplate.new(self, path, prefixes, partial, details, details_key, locals))
+    def find!(path, prefixes, partial, details, cache, locals)
+      find(path, prefixes, partial, details, cache, locals) ||
+        raise(MissingTemplate.new(self, path, prefixes, partial, details, cache, locals))
     end
 
-    def find_all(path, prefixes, partial, details, details_key, locals)
+    def find_all(path, prefixes, partial, details, cache, locals)
       search_combinations(prefixes) do |resolver, prefix|
-        templates = resolver.find_all(path, prefix, partial, details, details_key, locals)
+        templates = resolver.find_all(path, prefix, partial, details, cache, locals)
         return templates unless templates.empty?
       end
       []
     end
 
-    def exists?(path, prefixes, partial, details, details_key, locals)
-      find_all(path, prefixes, partial, details, details_key, locals).any?
+    def exists?(path, prefixes, partial, details, cache, locals)
+      find_all(path, prefixes, partial, details, cache, locals).any?
     end
 
     private

--- a/actionview/lib/action_view/path_set.rb
+++ b/actionview/lib/action_view/path_set.rb
@@ -59,7 +59,10 @@ module ActionView # :nodoc:
     end
 
     def exists?(path, prefixes, partial, details, cache, locals)
-      find_all(path, prefixes, partial, details, cache, locals).any?
+      search_combinations(prefixes) do |resolver, prefix|
+        return true if resolver.find(path, prefix, partial, details, cache, locals)
+      end
+      false
     end
 
     private

--- a/actionview/lib/action_view/renderer/abstract_renderer.rb
+++ b/actionview/lib/action_view/renderer/abstract_renderer.rb
@@ -154,20 +154,6 @@ module ActionView
     end
 
     private
-      NO_DETAILS = {}.freeze
-
-      def extract_details(options) # :doc:
-        details = nil
-        LookupContext.registered_details.each do |key|
-          value = options[key]
-
-          if value
-            (details ||= {})[key] = Array(value)
-          end
-        end
-        details || NO_DETAILS
-      end
-
       def prepend_formats(formats) # :doc:
         formats = Array(formats)
         return if formats.empty? || @lookup_context.html_fallback_for_js

--- a/actionview/lib/action_view/renderer/partial_renderer.rb
+++ b/actionview/lib/action_view/renderer/partial_renderer.rb
@@ -240,7 +240,7 @@ module ActionView
       super(lookup_context)
       @options = options
       @locals  = @options[:locals] || {}
-      @details = extract_details(@options)
+      @details = @lookup_context.details_for(@options)
     end
 
     def render(partial, context, block)

--- a/actionview/lib/action_view/renderer/template_renderer.rb
+++ b/actionview/lib/action_view/renderer/template_renderer.rb
@@ -3,7 +3,7 @@
 module ActionView
   class TemplateRenderer < AbstractRenderer # :nodoc:
     def render(context, options, &block)
-      @details = extract_details(options)
+      @details = @lookup_context.details_for(options)
       template = determine_template(options, &block)
 
       prepend_formats(template.format)

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -57,8 +57,8 @@ module ActionView
     end
 
     # Normalizes the arguments and passes it on to find_templates.
-    def find_all(name, prefix = nil, partial = false, details = {}, key = nil, locals = [])
-      _find_all(name, prefix, partial, details, key, locals)
+    def find_all(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
+      _find_all(name, prefix, partial, details, cache, locals)
     end
 
     def built_templates # :nodoc:
@@ -72,7 +72,7 @@ module ActionView
     end
 
   private
-    def _find_all(name, prefix, partial, details, key, locals)
+    def _find_all(name, prefix, partial, details, cache, locals)
       find_templates(name, prefix, partial, details, locals)
     end
 
@@ -128,12 +128,12 @@ module ActionView
     end
 
     private
-      def _find_all(name, prefix, partial, details, key, locals)
-        requested_details = key || TemplateDetails::Requested.new(**details)
-        cache = key ? @unbound_templates : Concurrent::Map.new
+      def _find_all(name, prefix, partial, details, cache, locals)
+        requested_details = TemplateDetails::Requested.new(**details)
+        store = cache ? @unbound_templates : Concurrent::Map.new
 
         unbound_templates =
-          cache.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
+          store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
             path = TemplatePath.build(name, prefix, partial)
             unbound_templates_from_path(path)
           end

--- a/actionview/lib/action_view/template/resolver.rb
+++ b/actionview/lib/action_view/template/resolver.rb
@@ -3,6 +3,7 @@
 require "pathname"
 require "active_support/core_ext/class"
 require "active_support/core_ext/module/attribute_accessors"
+require "active_support/core_ext/string/access"
 require "action_view/template"
 require "concurrent/map"
 
@@ -56,9 +57,15 @@ module ActionView
     def clear_cache
     end
 
-    # Normalizes the arguments and passes it on to find_templates.
+    # Returns every matching template. The only multi-template caller is
+    # ActionMailer multipart; view rendering resolves via #find.
     def find_all(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
       _find_all(name, prefix, partial, details, cache, locals)
+    end
+
+    # Returns the single best-matching template.
+    def find(name, prefix = nil, partial = false, details = {}, cache = false, locals = [])
+      _find(name, prefix, partial, details, cache, locals)
     end
 
     def built_templates # :nodoc:
@@ -74,6 +81,10 @@ module ActionView
   private
     def _find_all(name, prefix, partial, details, cache, locals)
       find_templates(name, prefix, partial, details, locals)
+    end
+
+    def _find(name, prefix, partial, details, cache, locals)
+      find_all(name, prefix, partial, details, cache, locals).first
     end
 
     delegate :caching?, to: :class
@@ -129,17 +140,23 @@ module ActionView
 
     private
       def _find_all(name, prefix, partial, details, cache, locals)
-        requested_details = TemplateDetails::Requested.new(**details)
-        store = cache ? @unbound_templates : Concurrent::Map.new
+        unbound_templates = unbound_templates_for(name, prefix, partial, cache)
 
-        unbound_templates =
-          store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
-            path = TemplatePath.build(name, prefix, partial)
-            unbound_templates_from_path(path)
-          end
-
-        filter_and_sort_by_details(unbound_templates, requested_details).map do |unbound_template|
+        filter_and_sort_by_details(unbound_templates, details).map do |unbound_template|
           unbound_template.bind_locals(locals)
+        end
+      end
+
+      def _find(name, prefix, partial, details, cache, locals)
+        unbound_templates = unbound_templates_for(name, prefix, partial, cache)
+
+        find_best_by_details(unbound_templates, details)&.bind_locals(locals)
+      end
+
+      def unbound_templates_for(name, prefix, partial, cache)
+        store = cache ? @unbound_templates : Concurrent::Map.new
+        store.compute_if_absent(TemplatePath.virtual(name, prefix, partial)) do
+          unbound_templates_from_path(TemplatePath.build(name, prefix, partial))
         end
       end
 
@@ -177,18 +194,26 @@ module ActionView
         end
       end
 
-      def filter_and_sort_by_details(templates, requested_details)
-        filtered_templates = templates.select do |template|
-          template.details.matches?(requested_details)
+      def filter_and_sort_by_details(templates, details)
+        ranked = templates.filter_map do |template|
+          rank = details.template_rank(template)
+          [rank, template] if rank
         end
 
-        if filtered_templates.count > 1
-          filtered_templates.sort_by! do |template|
-            template.details.sort_key_for(requested_details)
+        ranked.sort_by!(&:first)
+        ranked.map!(&:last)
+      end
+
+      def find_best_by_details(templates, details)
+        best = best_rank = nil
+        templates.each do |template|
+          rank = details.template_rank(template) or next
+          if best_rank.nil? || (rank <=> best_rank) < 0
+            best = template
+            best_rank = rank
           end
         end
-
-        filtered_templates
+        best
       end
 
       # Safe glob within @path

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -39,22 +39,6 @@ module ActionView
       @variant = variant
     end
 
-    def matches?(requested)
-      requested.formats_idx[@format] &&
-        requested.locale_idx[@locale] &&
-        requested.variants_idx[@variant] &&
-        requested.handlers_idx[@handler]
-    end
-
-    def sort_key_for(requested)
-      [
-        requested.formats_idx[@format],
-        requested.locale_idx[@locale],
-        requested.variants_idx[@variant],
-        requested.handlers_idx[@handler]
-      ]
-    end
-
     def handler_class
       Template.handler_for_extension(handler)
     end

--- a/actionview/lib/action_view/template_details.rb
+++ b/actionview/lib/action_view/template_details.rb
@@ -2,34 +2,6 @@
 
 module ActionView
   class TemplateDetails # :nodoc:
-    class Requested
-      attr_reader :locale, :handlers, :formats, :variants
-      attr_reader :locale_idx, :handlers_idx, :formats_idx, :variants_idx
-
-      ANY_HASH = Hash.new(1).merge(nil => 0).freeze
-
-      def initialize(locale:, handlers:, formats:, variants:)
-        @locale = locale
-        @handlers = handlers
-        @formats = formats
-        @variants = variants
-
-        @locale_idx   = build_idx_hash(locale)
-        @handlers_idx = build_idx_hash(handlers)
-        @formats_idx  = build_idx_hash(formats)
-        if variants == :any
-          @variants_idx = ANY_HASH
-        else
-          @variants_idx = build_idx_hash(variants)
-        end
-      end
-
-      private
-        def build_idx_hash(arr)
-          [*arr, nil].each_with_index.to_h.freeze
-        end
-    end
-
     attr_reader :locale, :handler, :format, :variant
 
     def initialize(locale, handler, format, variant)

--- a/actionview/test/actionpack/controller/layout_test.rb
+++ b/actionview/test/actionpack/controller/layout_test.rb
@@ -19,12 +19,12 @@ module TemplateHandlerHelper
   def with_template_handler(*extensions, handler)
     ActionView::Template.register_template_handler(*extensions, handler)
     ActionController::Base.view_paths.paths.each(&:clear_cache)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     yield
   ensure
     ActionView::Template.unregister_template_handler(*extensions)
     ActionController::Base.view_paths.paths.each(&:clear_cache)
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 end
 

--- a/actionview/test/actionpack/controller/render_test.rb
+++ b/actionview/test/actionpack/controller/render_test.rb
@@ -1528,11 +1528,11 @@ class RenderTest < ActionController::TestCase
 
   def with_annotations_enabled
     ActionView::Base.annotate_rendered_view_with_filenames = true
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     yield
   ensure
     ActionView::Base.annotate_rendered_view_with_filenames = false
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_template_annotations

--- a/actionview/test/actionpack/controller/view_paths_test.rb
+++ b/actionview/test/actionpack/controller/view_paths_test.rb
@@ -30,7 +30,7 @@ class ViewLoadPathsTest < ActionController::TestCase
   end
 
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     @controller = TestController.new
     @request  = ActionController::TestRequest.create(@controller.class)

--- a/actionview/test/activerecord/render_partial_with_record_identification_test.rb
+++ b/actionview/test/activerecord/render_partial_with_record_identification_test.rb
@@ -54,7 +54,7 @@ class RenderPartialWithRecordIdentificationTest < ActiveRecordTestCase
 
   def setup
     super
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_rendering_partial_with_has_many_and_belongs_to_association

--- a/actionview/test/template/compiled_templates_test.rb
+++ b/actionview/test/template/compiled_templates_test.rb
@@ -14,7 +14,7 @@ class CompiledTemplatesTest < ActiveSupport::TestCase
 
   def teardown
     super
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def test_template_with_nil_erb_return

--- a/actionview/test/template/digestor_test.rb
+++ b/actionview/test/template/digestor_test.rb
@@ -23,7 +23,7 @@ class TemplateDigestorTest < ActionView::TestCase
     @cwd     = Dir.pwd
     @tmp_dir = Dir.mktmpdir
 
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     FileUtils.cp_r FixtureFinder::FIXTURES_DIR, @tmp_dir
     Dir.chdir @tmp_dir
   end

--- a/actionview/test/template/log_subscriber_test.rb
+++ b/actionview/test/template/log_subscriber_test.rb
@@ -21,7 +21,7 @@ class AVLogSubscriberTest < ActiveSupport::TestCase
     @old_logger = ActionView::LogSubscriber.logger
     ActionView::LogSubscriber.logger = @logger
 
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -127,28 +127,6 @@ class LookupContextTest < ActiveSupport::TestCase
     end
   end
 
-  test "generates a new details key for each details hash" do
-    keys = []
-    keys << @lookup_context.details_key
-    assert_equal 1, keys.uniq.size
-
-    @lookup_context.locale = :da
-    keys << @lookup_context.details_key
-    assert_equal 2, keys.uniq.size
-
-    @lookup_context.locale = :en
-    keys << @lookup_context.details_key
-    assert_equal 2, keys.uniq.size
-
-    @lookup_context.formats = [:html]
-    keys << @lookup_context.details_key
-    assert_equal 3, keys.uniq.size
-
-    @lookup_context.formats = nil
-    keys << @lookup_context.details_key
-    assert_equal 3, keys.uniq.size
-  end
-
   test "uses details as part of cache key" do
     fixtures = {
       "test/_foo.erb" => "Foo",

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -214,8 +214,7 @@ class TestMissingTemplate < ActiveSupport::TestCase
 
   test "if a single prefix is passed as a string and the lookup fails, MissingTemplate accepts it" do
     e = assert_raise ActionView::MissingTemplate do
-      details = { handlers: [], formats: [], variants: [], locale: [] }
-      @lookup_context.view_paths.find!("foo", "parent", true, details, nil, [])
+      @lookup_context.find!("foo", "parent", true)
     end
     assert_match %r{Missing partial parent/_foo with .*\n\nSearched in:\n  \* "/Path/to/views"\n}, e.message
   end

--- a/actionview/test/template/lookup_context_test.rb
+++ b/actionview/test/template/lookup_context_test.rb
@@ -6,7 +6,7 @@ require "abstract_controller/rendering"
 class LookupContextTest < ActiveSupport::TestCase
   def setup
     @lookup_context = build_lookup_context(FIXTURE_LOAD_PATH, {})
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
   end
 
   def build_lookup_context(paths, details)

--- a/actionview/test/template/render_test.rb
+++ b/actionview/test/template/render_test.rb
@@ -845,7 +845,7 @@ class FrozenStringLiteralEnabledViewRenderTest < ActiveSupport::TestCase
   include RenderTestCases
 
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     @previous_frozen_literal = ActionView::Template.frozen_string_literal
     ActionView::Template.frozen_string_literal = true
@@ -871,7 +871,7 @@ class CachedViewRenderTest < ActiveSupport::TestCase
 
   # Ensure view path cache is primed
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     view_paths = ActionController::Base.view_paths
     assert_equal ActionView::FileSystemResolver, view_paths.first.class
     setup_view(view_paths)
@@ -909,7 +909,7 @@ class LazyViewRenderTest < ActiveSupport::TestCase
   # Test the same thing as above, but make sure the view path
   # is not eager loaded
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
     path = ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH)
     view_paths = ActionView::PathSet.new([path])
     assert_equal ActionView::FileSystemResolver.new(FIXTURE_LOAD_PATH), view_paths.first
@@ -962,7 +962,7 @@ class CachedCollectionViewRenderTest < ActiveSupport::TestCase
 
   # Ensure view path cache is primed
   setup do
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
     assert_equal ActionView::FileSystemResolver, view_paths.first.class

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -102,17 +102,17 @@ module ResolverSharedTests
   def test_found_template_is_cached
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], {})
-    b = context.find("hello_world", "test", false, [], {})
+    a = context.find("hello_world", "test", false, [])
+    b = context.find("hello_world", "test", false, [])
     assert_same a, b
   end
 
   def test_different_templates_when_cache_disabled
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], {})
-    b = context.disable_cache { context.find("hello_world", "test", false, [], {}) }
-    c = context.find("hello_world", "test", false, [], {})
+    a = context.find("hello_world", "test", false, [])
+    b = context.disable_cache { context.find("hello_world", "test", false, []) }
+    c = context.find("hello_world", "test", false, [])
 
     # disable_cache should give us a new object
     assert_not_same a, b
@@ -124,8 +124,8 @@ module ResolverSharedTests
   def test_same_template_from_different_details_is_same_object
     with_file "test/hello_world.html.erb", "Hello HTML!"
 
-    a = context.find("hello_world", "test", false, [], locale: [:en])
-    b = context.find("hello_world", "test", false, [], locale: [:fr])
+    a = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en]))
+    b = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:fr]))
     assert_same a, b
   end
 
@@ -133,8 +133,8 @@ module ResolverSharedTests
     with_file "test/hello_world.text.erb", "Generic plain text!"
     with_file "test/hello_world.fr.text.erb", "Texte en Francais!"
 
-    en = context.find_all("hello_world", "test", false, [], locale: [:en])
-    fr = context.find_all("hello_world", "test", false, [], locale: [:fr])
+    en = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en]))
+    fr = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:fr]))
 
     assert_equal 1, en.size
     assert_equal 2, fr.size
@@ -188,18 +188,18 @@ module ResolverSharedTests
     with_file "test/hello_world.html+tricorder.erb", "Hello Spock!"
     with_file "test/hello_world.html+lcars.erb", "Hello Geordi!"
 
-    tricorder = context.find("hello_world", "test", false, [], { variants: [:tricorder] })
-    lcars = context.find("hello_world", "test", false, [], { variants: [:lcars] })
+    tricorder = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:tricorder]))
+    lcars = context.find("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:lcars]))
 
     assert_equal "Hello Spock!", tricorder.source
     assert_equal "tricorder", tricorder.variant
     assert_equal "Hello Geordi!", lcars.source
     assert_equal "lcars", lcars.variant
 
-    templates = context.find_all("hello_world", "test", false, [], { variants: [:tricorder, :lcars] })
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:tricorder, :lcars]))
     assert_equal [tricorder, lcars], templates
 
-    templates = context.find_all("hello_world", "test", false, [], { variants: [:lcars, :tricorder] })
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(variants: [:lcars, :tricorder]))
     assert_equal [lcars, tricorder], templates
   end
 
@@ -230,13 +230,13 @@ module ResolverSharedTests
   def test_returns_no_results_with_dot
     with_file "test/hello_world.html.erb", "Hello html!"
 
-    assert_empty context.find_all("hello_world.html", "test", false, [], {})
+    assert_empty context.find_all("hello_world.html", "test", false, [])
   end
 
   def test_finds_template_with_lowdash_format
     with_file "test/hello_world.es_AR.text.erb", "Texto simple!"
 
-    es_ar = context.find_all("hello_world", "test", false, [], locale: [:es_AR])
+    es_ar = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:es_AR]))
 
     assert_equal 1, es_ar.size
 
@@ -247,7 +247,7 @@ module ResolverSharedTests
     I18n.backend.store_translations(:en_customer1, { hello: "hello" })
     with_file "test/hello_world.en_customer1.text.erb", "Good day, world."
 
-    templates = context.find_all("hello_world", "test", false, [], locale: [:en_customer1])
+    templates = context.find_all("hello_world", "test", false, [], ActionView::LookupContext::Details.new(locale: [:en_customer1]))
 
     assert_equal 1, templates.size
     assert_equal "Good day, world.", templates[0].source
@@ -258,8 +258,8 @@ module ResolverSharedTests
   def test_strict_locals_reuses_same_template
     with_file "test/hello_world.html.erb", %q{<%# locals: (message: "hello")%>\n<%= message %>}
 
-    template = context.find_all("hello_world", "test", false, [:message], {})[0]
-    template2 = context.find_all("hello_world", "test", false, [], {})[0]
+    template = context.find_all("hello_world", "test", false, [:message])[0]
+    template2 = context.find_all("hello_world", "test", false, [])[0]
 
     assert_same template, template2
 

--- a/actionview/test/template/resolver_shared_tests.rb
+++ b/actionview/test/template/resolver_shared_tests.rb
@@ -22,7 +22,7 @@ module ResolverSharedTests
   def test_can_find_with_no_extensions
     with_file "test/hello_world", "Hello default!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello default!",   templates[0].source
     assert_equal "test/hello_world", templates[0].virtual_path
@@ -34,7 +34,7 @@ module ResolverSharedTests
   def test_can_find_with_just_handler
     with_file "test/hello_world.erb", "Hello erb!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello erb!",   templates[0].source
     assert_equal "test/hello_world", templates[0].virtual_path
@@ -46,7 +46,7 @@ module ResolverSharedTests
   def test_can_find_with_format_and_handler
     with_file "test/hello_world.text.builder", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html, :text], variants: [:phone], handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html, :text], variants: [:phone], handlers: [:erb, :builder]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -58,7 +58,7 @@ module ResolverSharedTests
   def test_can_find_with_variant_format_and_handler
     with_file "test/hello_world.html+phone.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -70,7 +70,7 @@ module ResolverSharedTests
   def test_can_find_with_any_variant_format_and_handler
     with_file "test/hello_world.html+phone.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [:en], formats: [:html], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: :any, handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello plain text!", templates[0].source
     assert_equal "test/hello_world",  templates[0].virtual_path
@@ -83,7 +83,7 @@ module ResolverSharedTests
     dir = "test +()[]{}"
     with_file "#{dir}/hello_world", "Hello funky path!"
 
-    templates = resolver.find_all("hello_world", dir, false, locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb])
+    templates = resolver.find_all("hello_world", dir, false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [:phone], handlers: [:erb]))
     assert_equal 1, templates.size
     assert_equal "Hello funky path!", templates[0].source
     assert_equal "#{dir}/hello_world", templates[0].virtual_path
@@ -92,10 +92,10 @@ module ResolverSharedTests
   def test_doesnt_find_template_with_wrong_details
     with_file "test/hello_world.html.erb", "Hello plain text!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:xml], variants: :any, handlers: [:builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:xml], variants: :any, handlers: [:builder]))
     assert_equal 0, templates.size
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:xml], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:xml], variants: :any, handlers: [:erb]))
     assert_equal 0, templates.size
   end
 
@@ -150,7 +150,7 @@ module ResolverSharedTests
     with_file "test/hello_world.html.erb", "Hello HTML!"
     with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:json, :html], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 2, templates.size
     assert_equal "Hello JSON!", templates[0].source
@@ -163,7 +163,7 @@ module ResolverSharedTests
     with_file "test/hello_world.html.erb", "Hello HTML!"
     with_file "test/hello_world.json.builder", "Hello JSON!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 2, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -175,7 +175,7 @@ module ResolverSharedTests
   def test_templates_with_variant
     with_file "test/hello_world.html+mobile.erb", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -206,7 +206,7 @@ module ResolverSharedTests
   def test_templates_no_format_with_variant
     with_file "test/hello_world+mobile.erb", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source
@@ -218,7 +218,7 @@ module ResolverSharedTests
   def test_templates_no_format_or_handler_with_variant
     with_file "test/hello_world+mobile", "Hello HTML!"
 
-    templates = resolver.find_all("hello_world", "test", false, locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder])
+    templates = resolver.find_all("hello_world", "test", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html, :json], variants: :any, handlers: [:erb, :builder]))
 
     assert_equal 1, templates.size
     assert_equal "Hello HTML!", templates[0].source

--- a/actionview/test/template/streaming_render_test.rb
+++ b/actionview/test/template/streaming_render_test.rb
@@ -7,7 +7,7 @@ end
 
 class SetupFiberedBase < ActiveSupport::TestCase
   def setup
-    ActionView::LookupContext::DetailsKey.clear
+    ActionView::LookupContext.clear
 
     view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/structured_event_subscriber_test.rb
+++ b/actionview/test/template/structured_event_subscriber_test.rb
@@ -12,7 +12,7 @@ module ActionView
     def setup
       super
 
-      ActionView::LookupContext::DetailsKey.clear
+      ActionView::LookupContext.clear
 
       view_paths = ActionController::Base.view_paths
 

--- a/actionview/test/template/test_case_test.rb
+++ b/actionview/test/template/test_case_test.rb
@@ -26,7 +26,7 @@ module ActionView
 
     module SharedTests
       def setup
-        ActionView::LookupContext::DetailsKey.clear
+        ActionView::LookupContext.clear
         super
       end
 

--- a/actionview/test/template/testing/fixture_resolver_test.rb
+++ b/actionview/test/template/testing/fixture_resolver_test.rb
@@ -5,13 +5,13 @@ require "abstract_unit"
 class FixtureResolverTest < ActiveSupport::TestCase
   def test_should_return_empty_list_for_unknown_path
     resolver = ActionView::FixtureResolver.new()
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: []))
     assert_equal [], templates, "expected an empty list of templates"
   end
 
   def test_should_return_template_for_declared_path
     resolver = ActionView::FixtureResolver.new("arbitrary/path.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this text",      templates.first.source
     assert_equal "arbitrary/path", templates.first.virtual_path
@@ -20,7 +20,7 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_match_templates_with_variants
     resolver = ActionView::FixtureResolver.new("arbitrary/path.html+variant.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [:variant], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [:variant], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this text",       templates.first.source
     assert_equal "arbitrary/path",  templates.first.virtual_path
@@ -30,8 +30,8 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_match_locales
     resolver = ActionView::FixtureResolver.new("arbitrary/path.erb" => "this text", "arbitrary/path.fr.erb" => "ce texte")
-    en = resolver.find_all("path", "arbitrary", false, locale: [:en], formats: [:html], variants: [], handlers: [:erb])
-    fr = resolver.find_all("path", "arbitrary", false, locale: [:fr], formats: [:html], variants: [], handlers: [:erb])
+    en = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [:en], formats: [:html], variants: [], handlers: [:erb]))
+    fr = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [:fr], formats: [:html], variants: [], handlers: [:erb]))
 
     assert_equal 1, en.size
     assert_equal 2, fr.size
@@ -43,10 +43,10 @@ class FixtureResolverTest < ActiveSupport::TestCase
 
   def test_should_return_all_variants_for_any
     resolver = ActionView::FixtureResolver.new("arbitrary/path.html.erb" => "this html", "arbitrary/path.html+variant.erb" => "this text")
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: [], handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: [], handlers: [:erb]))
     assert_equal 1, templates.size, "expected one template"
     assert_equal "this html", templates.first.source
-    templates = resolver.find_all("path", "arbitrary", false, locale: [], formats: [:html], variants: :any, handlers: [:erb])
+    templates = resolver.find_all("path", "arbitrary", false, ActionView::LookupContext::Details.new(locale: [], formats: [:html], variants: :any, handlers: [:erb]))
     assert_equal 2, templates.size, "expected all templates"
   end
 end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -62,7 +62,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
   end
 
   test "template digests are cleared before a request" do
-    assert_called(ActionView::LookupContext::DetailsKey, :clear, times: 2) do
+    assert_called(ActionView::LookupContext, :clear, times: 2) do
       get "/customers"
       assert_equal 200, last_response.status
     end

--- a/railties/test/application/per_request_digest_cache_test.rb
+++ b/railties/test/application/per_request_digest_cache_test.rb
@@ -56,7 +56,7 @@ class PerRequestDigestCacheTest < ActiveSupport::TestCase
     get "/customers"
     assert_equal 200, last_response.status
 
-    values = ActionView::LookupContext::DetailsKey.digest_caches.first.values
+    values = ActionView::Digestor.digest_caches.first.values
     assert_equal [ "ddb451d2c1b2374caa676005893bb776" ], values
     assert_equal %w(david dingus), last_response.body.split.map(&:strip)
   end


### PR DESCRIPTION
Currently template lookup uses a ranking which interns ActionView::LookupContext::DetailsKey objects which hold hashes with index for faster comparison/ranking of templates and their details against the incoming request's details.

Since shared mutable caches like this are annoying for Ractors, I've looked into refactoring this to avoid the interning/caching, relying on https://github.com/rails/rails/pull/57783 to avoid having to build a rank for all templates before selecting the best one.