### PR TITLE
Cover polymorphic has_many :through with decoupled query_constraints source

### DIFF
--- a/activerecord/test/cases/associations_test.rb
+++ b/activerecord/test/cases/associations_test.rb
@@ -509,6 +509,49 @@ class AssociationsTest < ActiveRecord::TestCase
     assert_match(/#{tags_col} = #{join_col}/, sql)
   end
 
+  def test_has_many_through_with_polymorphic_decoupled_query_constraints_source_uses_all_constraints_in_join
+    blog_post = sharded_blog_posts(:great_post_blog_one)
+    expected_tag_ids = [
+      sharded_tags(:short_read_blog_one).id,
+      sharded_tags(:technical_blog_one).id,
+    ].sort
+
+    # A join row of a *different* polymorphic type, colliding on id with a tag in
+    # the same shard that is not otherwise linked to this post. The source_type
+    # discriminator must exclude it; were that filter dropped, the join would
+    # surface long_read_blog_one and fail the assert_equal below. This gives the
+    # type scope behavioral teeth (rolled back with the test transaction), rather
+    # than relying on the SQL-shape assertion alone.
+    Sharded::BlogPostTag.create!(
+      blog_id: blog_post.blog_id,
+      blog_post_id: blog_post.id,
+      taggable_type: "Sharded::BlogPost",
+      taggable_id: sharded_tags(:long_read_blog_one).id,
+    )
+
+    sql = capture_sql do
+      loaded_tags = blog_post.taggables_with_decoupled_qc.to_a
+      assert_equal expected_tag_ids, loaded_tags.map(&:id).sort
+    end.first
+
+    # Polymorphic source_type through whose source belongs_to carries decoupled
+    # query_constraints (the tenant/shard column). The middle->target join must
+    # scope on blog_id, not just taggable_id, or a row from another shard could
+    # match on id alone (cross-shard scatter).
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.blog_id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.blog_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+
+    tags_col = Regexp.escape(Sharded::Tag.lease_connection.quote_table_name("sharded_tags.id"))
+    join_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.taggable_id"))
+    assert_match(/#{tags_col} = #{join_col}/, sql)
+
+    # The polymorphic source_type must also scope the join on the type
+    # discriminator, so a same-id row of a different taggable_type cannot leak in.
+    type_col = Regexp.escape(Sharded::BlogPostTag.lease_connection.quote_table_name("sharded_blog_posts_tags.taggable_type"))
+    assert_match(/#{type_col} = /, sql)
+  end
+
   def test_using_query_constraints_is_allowed
     assert_nothing_raised do
       Sharded::BlogPost.has_many :qc_configured_comments,

--- a/activerecord/test/fixtures/sharded_blog_posts_tags.yml
+++ b/activerecord/test/fixtures/sharded_blog_posts_tags.yml
@@ -5,23 +5,33 @@ short_read_first_post_blog_one:
   tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
   blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+  taggable_type: "Sharded::Tag"
+  taggable_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
 
 technical_content_first_post_blog_one:
   tag_id: <%= ActiveRecord::FixtureSet.identify(:technical_blog_one) %>
   blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+  taggable_type: "Sharded::Tag"
+  taggable_id: <%= ActiveRecord::FixtureSet.identify(:technical_blog_one) %>
 
 short_read_second_post_blog_one:
   tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
   blog_post_id: <%= ActiveRecord::FixtureSet.identify(:second_post_blog_one) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_one) %>
+  taggable_type: "Sharded::Tag"
+  taggable_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_one) %>
 
 beginner_content_first_post_blog_two:
   tag_id: <%= ActiveRecord::FixtureSet.identify(:beginner_blog_two) %>
   blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+  taggable_type: "Sharded::Tag"
+  taggable_id: <%= ActiveRecord::FixtureSet.identify(:beginner_blog_two) %>
 
 short_read_first_post_blog_two:
   tag_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_two) %>
   blog_post_id: <%= ActiveRecord::FixtureSet.identify(:great_post_blog_two) %>
   blog_id: <%= ActiveRecord::FixtureSet.identify(:sharded_blog_two) %>
+  taggable_type: "Sharded::Tag"
+  taggable_id: <%= ActiveRecord::FixtureSet.identify(:short_read_blog_two) %>

--- a/activerecord/test/models/sharded/blog_post.rb
+++ b/activerecord/test/models/sharded/blog_post.rb
@@ -20,6 +20,10 @@ module Sharded
     has_many :tags_with_decoupled_qc,
       through: :blog_post_tags_with_decoupled_qc,
       source: :tag_with_decoupled_qc
+    has_many :taggables_with_decoupled_qc,
+      through: :blog_post_tags_with_decoupled_qc,
+      source: :taggable_with_decoupled_qc,
+      source_type: "Sharded::Tag"
 
     has_and_belongs_to_many :tags_with_composite_fk,
       class_name: "Sharded::Tag",

--- a/activerecord/test/models/sharded/blog_post_tag.rb
+++ b/activerecord/test/models/sharded/blog_post_tag.rb
@@ -8,5 +8,15 @@ module Sharded
     belongs_to :blog_post
     belongs_to :tag
     belongs_to :tag_with_decoupled_qc, class_name: "Sharded::Tag", foreign_key: :tag_id, query_constraints: :blog_id
+    # foreign_type is set explicitly because the association name
+    # (taggable_with_decoupled_qc) diverges from the taggable_* column prefix, so
+    # the default derived type column (taggable_with_decoupled_qc_type) would not
+    # exist. The decoupled query_constraints feature itself does not require it;
+    # the motivating :region shape (region_id/region_type) needs no override.
+    belongs_to :taggable_with_decoupled_qc,
+      polymorphic: true,
+      foreign_key: :taggable_id,
+      foreign_type: :taggable_type,
+      query_constraints: :blog_id
   end
 end

--- a/activerecord/test/schema/schema.rb
+++ b/activerecord/test/schema/schema.rb
@@ -377,6 +377,8 @@ ActiveRecord::Schema.define do
     t.integer :blog_id
     t.integer :blog_post_id
     t.integer :tag_id
+    t.string :taggable_type
+    t.integer :taggable_id
   end
 
   create_table :shipments, force: true do |t|


### PR DESCRIPTION
## Summary

Adds ActiveRecord test coverage for a **polymorphic** `has_many :through`
whose source `belongs_to` uses the decoupled `query_constraints` introduced
in #51. #51's only `:through` coverage used a single-type source
(`tags_with_decoupled_qc` -> `Sharded::Tag`); the polymorphic shape that
motivates the feature was untested.

The motivating case comes from World Delivery models:
`Zone has_many :through -> DeliveryZoneRegion belongs_to(polymorphic :region)
-> Country/Province`, where the tenant/shard column (`shop_id` in World,
`blog_id` in these fixtures) must be folded into the read-side join for the
polymorphic source.

## Result

**#51 already handles the polymorphic case correctly.** The new test confirms
the middle->target join scopes on all three constraints — the decoupled query
constraint (`blog_id`), the polymorphic id (`taggable_id`), and the polymorphic
type discriminator (`taggable_type`) — so a row from another shard cannot match
on id alone, and a same-id row of a different taggable_type cannot leak in:

```sql
INNER JOIN "sharded_blog_posts_tags"
  ON "sharded_tags"."blog_id" = "sharded_blog_posts_tags"."blog_id"
 AND "sharded_tags"."id"      = "sharded_blog_posts_tags"."taggable_id"
WHERE ... AND "sharded_blog_posts_tags"."taggable_type" = ?
```

## Approach

- New polymorphic `belongs_to :taggable_with_decoupled_qc` on
  `Sharded::BlogPostTag` (FK `taggable_id`, `query_constraints: :blog_id`),
  reached through `Sharded::BlogPost#taggables_with_decoupled_qc`
  (`source_type: "Sharded::Tag"`).
- The only fix required was in the **test scaffolding**, not the framework: a
  polymorphic `belongs_to` derives its type column from the association name
  (`reflection.rb`: `"#{name}_type"`), so `taggable_with_decoupled_qc` looked
  for a `taggable_with_decoupled_qc_type` column while the schema/FK use the
  `taggable_` prefix. Pinning `foreign_type: :taggable_type` aligns the type
  column with the `taggable_id` foreign key. **`reflection.rb` is untouched.**
- The test asserts the `taggable_type` discriminator predicate in the SQL and
  additionally creates a transient wrong-type join row (rolled back with the
  test transaction) so the `source_type` scope is guarded behaviorally, not
  just by SQL shape.

Stacked on #51 (base: `introduce-decoupled-query-constraints`).

Co-authored-by: Claude Opus 4.8 <noreply@anthropic.com>
Orchestrated-by: ae <noreply@shopify.com>

<!-- ae-body-hash:a870b1247f039d5e402e6b6e3f51bab6ae34117481f3148dec268238a4e3920f -->
