### PR TITLE
Remove unused ConnectionHandler#pool_managers method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_handler.rb
@@ -247,10 +247,6 @@ module ActiveRecord
           connection_name_to_pool_manager[connection_descriptor.name] ||= PoolManager.new
         end
 
-        def pool_managers
-          connection_name_to_pool_manager.values
-        end
-
         def disconnect_pool_from_pool_manager(pool_manager, role, shard)
           pool_config = pool_manager.remove_pool_config(role, shard)
 


### PR DESCRIPTION
The helper was added in 74cb960e66 for deprecation_for_pool_handling. Commit 64cbcd7a8c removed that deprecation path, leaving pool_managers without a caller.
