### PR TITLE
Remove unused ConnectionPool#remove_from_maintenance method

### DIFF
--- a/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
+++ b/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb
@@ -992,8 +992,8 @@ module ActiveRecord
 
         # Directly check a specific connection out of the pool. Skips callbacks.
         #
-        # The connection must later either #return_from_maintenance or
-        # #remove_from_maintenance, or the pool will hang.
+        # The connection must later be returned with #return_from_maintenance, or
+        # the pool will hang.
         def checkout_for_maintenance(conn)
           synchronize do
             @maintaining += 1
@@ -1019,15 +1019,6 @@ module ActiveRecord
           end
         end
 
-        # Remove a connection from the pool after it has been checked out for
-        # maintenance. It will be automatically replaced with a new connection if
-        # necessary.
-        def remove_from_maintenance(conn)
-          synchronize do
-            @maintaining -= 1
-            remove conn
-          end
-        end
 
         #--
         # this is unfortunately not concurrent


### PR DESCRIPTION
# TL;DR

Remove the unused private `ConnectionPool#remove_from_maintenance` method and update the maintenance checkout documentation to describe the only completion path Rails uses.

# Context

`5eab03f7b0e8a12871bbe3929a5297491915f586` introduced `checkout_for_maintenance`, `return_from_maintenance`, and `remove_from_maintenance` together. The accompanying documentation deliberately presented the latter two as symmetric ways to complete a maintenance checkout.

Rails never wired up the removal half of that pair. Every maintenance path returns the borrowed connection through `return_from_maintenance`, including the `ensure` block in `sequential_maintenance`. Rubydex, Ruby LSP, and a whole-tree search find no caller for `remove_from_maintenance`; only its declaration and the documentation naming it remain.

This therefore removes one half of a documented private pair rather than a dead-on-arrival accident. Since the method is private and has no in-tree caller, keeping the unused path does not preserve a supported API. If a future maintenance flow needs to discard a borrowed connection, the implementation is small and remains available in Git history to restore alongside its first caller and focused tests.