### PR TITLE
Deprecate mutating the `default_url_options`:

### DIFF
--- a/actionmailer/test/url_test.rb
+++ b/actionmailer/test/url_test.rb
@@ -18,7 +18,9 @@ end
 class UrlTestMailer < ActionMailer::Base
   include AppRoutes.url_helpers
 
-  default_url_options[:host] = "www.basecamphq.com"
+  def default_url_options
+    { host: "www.basecamphq.com" }
+  end
 
   configure do |c|
     c.assets_dir = "" # To get the tests to pass

--- a/actionpack/lib/action_dispatch/routing/url_for.rb
+++ b/actionpack/lib/action_dispatch/routing/url_for.rb
@@ -90,6 +90,42 @@ module ActionDispatch
     #     User.find(1).base_uri # => "/users/1"
     #
     module UrlFor
+      class DefaultUrlOptionsProxy # :nodoc:
+        def initialize(owner)
+          @owner = owner
+        end
+
+        def to_hash
+          @owner.default_url_options_hash
+        end
+
+        def method_missing(name, *args)
+          return super unless @owner.default_url_options_hash.respond_to?(name)
+
+          @owner.default_url_options_hash.public_send(name, *args)
+        rescue FrozenError
+          trigger_deprecation
+
+          @owner.default_url_options_hash = @owner.default_url_options_hash.dup
+          @owner.default_url_options_hash.public_send(name, *args)
+        end
+
+        def respond_to_missing?(name, _)
+          @owner.respond_to?(name) || super
+        end
+
+        private
+
+        def trigger_deprecation
+          ActionController.deprecator.warn(<<~MSG.squish)
+            Mutating the `default_url_options` is deprecated and will raise a FrozenError in the next
+            Rails release. Mutating the `default_url_options` can be a source of hard to debug issues.
+
+            Instead, implement `def default_url_options` in your class or controller.
+          MSG
+        end
+      end
+
       extend ActiveSupport::Concern
       include PolymorphicRoutes
 
@@ -97,12 +133,13 @@ module ActionDispatch
         unless method_defined?(:default_url_options)
           # Including in a class uses an inheritable hash. Modules get a plain hash.
           if respond_to?(:class_attribute)
-            class_attribute :default_url_options
+            class_attribute :default_url_options, :default_url_options_hash
           else
-            mattr_writer :default_url_options
+            mattr_writer :default_url_options, :default_url_options_hash
           end
 
-          self.default_url_options = {}
+          self.default_url_options_hash = {}.freeze
+          self.default_url_options = DefaultUrlOptionsProxy.new(self).freeze
         end
 
         include(*_url_for_modules) if respond_to?(:_url_for_modules)

--- a/actionpack/lib/action_dispatch/testing/integration.rb
+++ b/actionpack/lib/action_dispatch/testing/integration.rb
@@ -138,7 +138,8 @@ module ActionDispatch
       end
 
       def url_options
-        @url_options ||= default_url_options.dup.tap do |url_options|
+        @url_options ||= begin
+          url_options = {}.merge(default_url_options)
           url_options.reverse_merge!(controller.url_options) if controller.respond_to?(:url_options)
 
           if @app.respond_to?(:routes)

--- a/actionview/test/activerecord/polymorphic_routes_test.rb
+++ b/actionview/test/activerecord/polymorphic_routes_test.rb
@@ -66,7 +66,9 @@ class PolymorphicRoutesTest < ActionController::TestCase
   Routes.draw { }
   include Routes.url_helpers
 
-  default_url_options[:host] = "example.com"
+  def default_url_options
+    { host: "example.com" }
+  end
 
   def setup
     super
@@ -83,7 +85,7 @@ class PolymorphicRoutesTest < ActionController::TestCase
   end
 
   def assert_url(url, args)
-    host = self.class.default_url_options[:host]
+    host = default_url_options[:host]
 
     assert_equal url.delete_prefix("http://#{host}"), polymorphic_path(args)
     assert_equal url, polymorphic_url(args)
@@ -741,7 +743,7 @@ class PolymorphicPathRoutesTest < PolymorphicRoutesTest
   attr_accessor :controller
 
   def assert_url(url, args)
-    host = self.class.default_url_options[:host]
+    host = default_url_options[:host]
 
     assert_equal url.delete_prefix("http://#{host}"), url_for(args)
   end


### PR DESCRIPTION
- ### Context

  This patch is about the `default_url_options` used to tweak the generated urls when calling for instance `my_route_path` inside *controllers/views*. There is another `default_url_options` at the RouteSet but this patch is not about this one.

  ### Problem

  Mutating the `default_url_options` is nowhere documented and the recommended way to customize generated urls is to override the `default_url_options` method and override it.

  The issue being that the Rails tests suite uses that pattern, and while I don't know whether this is also done in the wild, I picked the precautious path.

  Mutating the `default_url_options` can create super weird behaviour:

  ```ruby
  class ApplicationController
    def hello_world
      redirect_to(root_path)
    end
  end

  class MyController < ApplicationController
    default_url_options[:lang] = "en"
  end
  ```

  In a autoloaded context, if a user hit the `/hello_world` path it will get redirected to `/`. Once the `MyController` is autoloaded , revisiting `/hello_world` will this time redirect to `/?lang=en`.

  ### Solution

  This patch freeze the default_url_options by default but still allows the hash to be mutated and trigger a deprecation message.

  This is done using a proxy which rescue from FrozenError anytime a mutation happens and duplicate the underlying hash.